### PR TITLE
Fixed add function

### DIFF
--- a/src/Stribog.java
+++ b/src/Stribog.java
@@ -59,7 +59,7 @@ public abstract class Stribog extends MessageDigestSpi {
 		int r = 0;
 		for (int i = a.length - 1; i >= 0; i--) {
 			result[i] = a[i] + b[i] + r & 0xFF;
-			r = a[i] + b[i] >> 8 & 0xFF;
+			r = a[i] + b[i] + r >> 8 & 0xFF;
 		}
 		return result;
 	}


### PR DESCRIPTION
The Stribog.add function works incorrectly for some given values. For example, lets assume at some point variables have following values:

```
r = 1
a[i] = 255
b[i] = 0
```

Then `result[i]` would become `0`, which is correct, but `r` would become `0` also, which is wrong as `result[i]` has just overflown and `r` should be `1`. This leads to incorrect digest for some input data.

Please review my change.
